### PR TITLE
Speed up _get_current_line() (take 2)

### DIFF
--- a/everywordbot.py
+++ b/everywordbot.py
@@ -30,8 +30,8 @@ class EverywordBot(object):
         with open(self.source_file_name) as source_fh:
             # read up until the desired line
             for i in range(index+1):
-                status_str = source_fh.readline().strip()
-            return status_str
+                status_str = source_fh.readline()
+            return status_str.strip()
 
     def post(self):
         index = self._get_current_index()

--- a/everywordbot.py
+++ b/everywordbot.py
@@ -28,9 +28,10 @@ class EverywordBot(object):
 
     def _get_current_line(self, index):
         with open(self.source_file_name) as source_fh:
-            # read up until the desired line
-            for i in range(index+1):
-                status_str = source_fh.readline()
+            # read the desired line
+            for i, status_str in enumerate(source_fh):
+                if i == index:
+                    break
             return status_str.strip()
 
     def post(self):


### PR DESCRIPTION
After re-evaluating the options from #3, here's a new PR.

For these tests, I've remove the 100 loop so `line = bot._get_current_line(index)` is only called once and increased the source file to 4,000,000 lines. The time quoted is that in `Ran 4 tests in 1.291s`. I ran it three times to make sure the value was representative (Python 2.7, Windows 7).

Search for the penultimate line:

1.788s Original implementation
1.291s `Only strip one line. For large file: 4.2s -> 3.0s`
**0.499s** `Don't readline every line. For large file: 4.2s -> 1.3s`
1.084s `Read all lines in one go. For large file: 4.2s -> 1.2s`
0.508s `Use linecache. For large file: 4.2s -> 0.2s`

And again reading in a line from halfway:

0.877s Original implementation
0.632s `Only strip one line. For large file: 4.2s -> 3.0s`
**0.238s** `Don't readline every line. For large file: 4.2s -> 1.3s`
0.999s `Read all lines in one go. For large file: 4.2s -> 1.2s`
0.480s `Use linecache. For large file: 4.2s -> 0.2s`

And finally from near the start of the file:

**0.013s** Original implementation
**0.012s** `Only strip one line. For large file: 4.2s -> 3.0s`
**0.013s** `Don't readline every line. For large file: 4.2s -> 1.3s`
0.994s `Read all lines in one go. For large file: 4.2s -> 1.2s`
0.475s `Use linecache. For large file: 4.2s -> 0.2s`

The [third one](https://github.com/hugovk/everywordbot/commit/5261166ddad385e523b503b9c9e54e0bfcad9ef7), using `enumerate(x)` (which uses `x.next()`),  is the best.
