### PR TITLE
Add lat/long or place_ID location to tweets

### DIFF
--- a/everywordbot.py
+++ b/everywordbot.py
@@ -6,9 +6,13 @@ class EverywordBot(object):
 
     def __init__(self, consumer_key, consumer_secret,
                  access_token, token_secret,
-                 source_file_name, index_file_name):
+                 source_file_name, index_file_name,
+                 lat=None, long=None, place_id=None):
         self.source_file_name = source_file_name
         self.index_file_name = index_file_name
+        self.lat = lat
+        self.long = long
+        self.place_id = place_id
 
         auth = tweepy.OAuthHandler(consumer_key, consumer_secret)
         auth.set_access_token(access_token, token_secret)
@@ -36,7 +40,9 @@ class EverywordBot(object):
     def post(self):
         index = self._get_current_index()
         status_str = self._get_current_line(index)
-        self.twitter.update_status(status=status_str)
+        self.twitter.update_status(status=status_str,
+                                   lat=self.lat, long=self.long,
+                                   place_id=self.place_id)
         self._increment_index(index)
 
 if __name__ == '__main__':
@@ -56,10 +62,17 @@ if __name__ == '__main__':
     parser.add_option('--index_file', dest='index_file',
                       default="index",
                       help="index file (must be able to write to this file)")
+    parser.add_option('--lat', dest='lat',
+                      help="The latitude for tweets")
+    parser.add_option('--long', dest='long',
+                      help="The longitude for tweets")
+    parser.add_option('--place_id', dest='place_id',
+                      help="Twitter ID of location for tweets")
     (options, args) = parser.parse_args()
 
     bot = EverywordBot(options.consumer_key, options.consumer_secret,
                        options.access_token, options.token_secret,
-                       options.source_file, options.index_file)
+                       options.source_file, options.index_file,
+                       options.lat, options.long, options.place_id)
 
     bot.post()

--- a/test/test_everywordbot.py
+++ b/test/test_everywordbot.py
@@ -13,7 +13,7 @@ sys.path.append(
 from everywordbot import EverywordBot
 
 
-def stub_twitter_update_status(status):
+def stub_twitter_update_status(status, lat=None, long=None, place_id=None):
     pass
 
 


### PR DESCRIPTION
Add Tweepy/Twitter's location parameters:
http://docs.tweepy.org/en/v3.3.0/api.html#API.update_status

Some examples from testing:

no location
https://twitter.com/kaikkisanat/status/601836399277531137

place_id
Tweet has "Helsinki, Finland" place link
https://twitter.com/kaikkisanat/status/601828849970761728

lat, long
Tweet has "Helsinki, Finland" place link
Also, my phone Twitter client shows a map
https://twitter.com/kaikkisanat/status/601849707502161920

lat, long, place_id
Tweet has "Helsinki, Finland" place link
Also, my phone Twitter client shows a map
https://twitter.com/kaikkisanat/status/601859048460398592
