### PR TITLE
Add options for specifying a prefix and/or suffix

### DIFF
--- a/everywordbot.py
+++ b/everywordbot.py
@@ -7,12 +7,15 @@ class EverywordBot(object):
     def __init__(self, consumer_key, consumer_secret,
                  access_token, token_secret,
                  source_file_name, index_file_name,
-                 lat=None, long=None, place_id=None):
+                 lat=None, long=None, place_id=None,
+                 prefix=None, suffix=None):
         self.source_file_name = source_file_name
         self.index_file_name = index_file_name
         self.lat = lat
         self.long = long
         self.place_id = place_id
+        self.prefix = prefix
+        self.suffix = suffix
 
         auth = tweepy.OAuthHandler(consumer_key, consumer_secret)
         auth.set_access_token(access_token, token_secret)
@@ -41,6 +44,10 @@ class EverywordBot(object):
     def post(self):
         index = self._get_current_index()
         status_str = self._get_current_line(index)
+        if self.prefix:
+            status_str = self.prefix + status_str
+        if self.suffix:
+            status_str = status_str + self.suffix
         self.twitter.update_status(status=status_str,
                                    lat=self.lat, long=self.long,
                                    place_id=self.place_id)
@@ -69,11 +76,16 @@ if __name__ == '__main__':
                       help="The longitude for tweets")
     parser.add_option('--place_id', dest='place_id',
                       help="Twitter ID of location for tweets")
+    parser.add_option('--prefix', dest='prefix',
+                      help="string to add to the beginning of each post (if you want a space, include a space)")
+    parser.add_option('--suffix', dest='suffix',
+                      help="string to add to the end of each post (if you want a space, include a space)")
     (options, args) = parser.parse_args()
 
     bot = EverywordBot(options.consumer_key, options.consumer_secret,
                        options.access_token, options.token_secret,
                        options.source_file, options.index_file,
-                       options.lat, options.long, options.place_id)
+                       options.lat, options.long, options.place_id,
+                       options.prefix, options.suffix)
 
     bot.post()

--- a/test/test_everywordbot.py
+++ b/test/test_everywordbot.py
@@ -13,8 +13,18 @@ sys.path.append(
 from everywordbot import EverywordBot
 
 
-def stub_twitter_update_status(status, lat=None, long=None, place_id=None):
-    pass
+class TwitterStub(object):
+    def __init__(self):
+        self.status = None
+        self.lat = None
+        self.long = None
+        self.place_id = None
+
+    def twitter_update_status(self, status, lat=None, long=None, place_id=None):
+        self.status = status
+        self.lat = lat
+        self.long = long
+        self.place_id = place_id
 
 
 class TestIt(unittest.TestCase):
@@ -62,7 +72,8 @@ class TestIt(unittest.TestCase):
         bot = EverywordBot("consumer_key", "consumer_secret",
                            "access_token", "token_secret",
                            "test/test_source.txt", "test/test_index.txt")
-        bot.twitter.update_status = stub_twitter_update_status
+        stub = TwitterStub()
+        bot.twitter.update_status = stub.twitter_update_status
         index_before = bot._get_current_index()
 
         # Act
@@ -71,6 +82,54 @@ class TestIt(unittest.TestCase):
         # Assert
         index_after = bot._get_current_index()
         self.assertEqual(index_before + 1, index_after)
+
+    def test__prefix(self):
+        # Arrange
+        bot = EverywordBot("consumer_key", "consumer_secret",
+                           "access_token", "token_secret",
+                           "test/test_source.txt", "index_file",
+                           prefix="aardvark ")
+        bot._get_current_line = lambda index: "word"
+        stub = TwitterStub()
+        bot.twitter.update_status = stub.twitter_update_status
+
+        # Act
+        bot.post()
+
+        # Assert
+        self.assertEqual(stub.status, "aardvark word")
+
+    def test__suffix(self):
+        # Arrange
+        bot = EverywordBot("consumer_key", "consumer_secret",
+                           "access_token", "token_secret",
+                           "test/test_source.txt", "index_file",
+                           suffix=" zebra")
+        bot._get_current_line = lambda index: "word"
+        stub = TwitterStub()
+        bot.twitter.update_status = stub.twitter_update_status
+
+        # Act
+        bot.post()
+
+        # Assert
+        self.assertEqual(stub.status, "word zebra")
+
+    def test__prefix_and_suffix(self):
+        # Arrange
+        bot = EverywordBot("consumer_key", "consumer_secret",
+                           "access_token", "token_secret",
+                           "test/test_source.txt", "index_file",
+                           prefix="apple-", suffix="-zucchini")
+        bot._get_current_line = lambda index: "word"
+        stub = TwitterStub()
+        bot.twitter.update_status = stub.twitter_update_status
+
+        # Act
+        bot.post()
+
+        # Assert
+        self.assertEqual(stub.status, "apple-word-zucchini")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Sometimes you might want to [add something](https://twitter.com/fuckeveryword) to [every tweet](https://twitter.com/artisanalwords). This allows for that without requiring a change to the word list.

I also set up a little stub to make pulling info out of the `update_status` call. (For example, this makes the `place_id` stuff testable)
