### PR TITLE
Add --bbox option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ target/
 
 # Temporary test files
 test/test_index.txt
+
+index_file

--- a/everywordbot.py
+++ b/everywordbot.py
@@ -8,7 +8,7 @@ class EverywordBot(object):
                  access_token, token_secret,
                  source_file_name, index_file_name,
                  lat=None, long=None, place_id=None,
-                 prefix=None, suffix=None):
+                 prefix=None, suffix=None, bbox=None):
         self.source_file_name = source_file_name
         self.index_file_name = index_file_name
         self.lat = lat
@@ -16,6 +16,7 @@ class EverywordBot(object):
         self.place_id = place_id
         self.prefix = prefix
         self.suffix = suffix
+        self.bbox = bbox
 
         auth = tweepy.OAuthHandler(consumer_key, consumer_secret)
         auth.set_access_token(access_token, token_secret)
@@ -41,6 +42,14 @@ class EverywordBot(object):
                     break
             return status_str.strip()
 
+    def _random_point_in(self, bbox):
+        """Given a bounding box of (swlat, swlon, nelat, nelon),
+         return random (lat, long)"""
+        import random
+        lat = random.uniform(bbox[0], bbox[2])
+        long = random.uniform(bbox[1], bbox[3])
+        return (lat, long)
+
     def post(self):
         index = self._get_current_index()
         status_str = self._get_current_line(index)
@@ -48,12 +57,24 @@ class EverywordBot(object):
             status_str = self.prefix + status_str
         if self.suffix:
             status_str = status_str + self.suffix
+        if self.bbox:
+            self.lat, self.long = self._random_point_in(self.bbox)
+
         self.twitter.update_status(status=status_str,
                                    lat=self.lat, long=self.long,
                                    place_id=self.place_id)
         self._increment_index(index)
 
+
+def _csv_to_float_list(csv):
+    return map(float, csv.split(','))
+
+
 if __name__ == '__main__':
+
+    def _get_comma_separated_args(option, opt, value, parser):
+        setattr(parser.values, option.dest, _csv_to_float_list(value))
+
     from optparse import OptionParser
     parser = OptionParser()
     parser.add_option('--consumer_key', dest='consumer_key',
@@ -76,6 +97,12 @@ if __name__ == '__main__':
                       help="The longitude for tweets")
     parser.add_option('--place_id', dest='place_id',
                       help="Twitter ID of location for tweets")
+    parser.add_option('--bbox', dest='bbox',
+                      type='string',
+                      action='callback',
+                      callback=_get_comma_separated_args,
+                      help="Bounding box (swlat, swlon, nelat, nelon) "
+                           "of random tweet location")
     parser.add_option('--prefix', dest='prefix',
                       help="string to add to the beginning of each post "
                            "(if you want a space, include a space)")
@@ -88,6 +115,6 @@ if __name__ == '__main__':
                        options.access_token, options.token_secret,
                        options.source_file, options.index_file,
                        options.lat, options.long, options.place_id,
-                       options.prefix, options.suffix)
+                       options.prefix, options.suffix, options.bbox)
 
     bot.post()

--- a/everywordbot.py
+++ b/everywordbot.py
@@ -67,7 +67,7 @@ class EverywordBot(object):
 
 
 def _csv_to_float_list(csv):
-    return map(float, csv.split(','))
+    return list(map(float, csv.split(',')))
 
 
 if __name__ == '__main__':

--- a/everywordbot.py
+++ b/everywordbot.py
@@ -77,9 +77,11 @@ if __name__ == '__main__':
     parser.add_option('--place_id', dest='place_id',
                       help="Twitter ID of location for tweets")
     parser.add_option('--prefix', dest='prefix',
-                      help="string to add to the beginning of each post (if you want a space, include a space)")
+                      help="string to add to the beginning of each post "
+                           "(if you want a space, include a space)")
     parser.add_option('--suffix', dest='suffix',
-                      help="string to add to the end of each post (if you want a space, include a space)")
+                      help="string to add to the end of each post "
+                           "(if you want a space, include a space)")
     (options, args) = parser.parse_args()
 
     bot = EverywordBot(options.consumer_key, options.consumer_secret,

--- a/test/test_everywordbot.py
+++ b/test/test_everywordbot.py
@@ -20,7 +20,8 @@ class TwitterStub(object):
         self.long = None
         self.place_id = None
 
-    def twitter_update_status(self, status, lat=None, long=None, place_id=None):
+    def twitter_update_status(self, status, lat=None, long=None,
+                              place_id=None):
         self.status = status
         self.lat = lat
         self.long = long


### PR DESCRIPTION
Rather than monotonously tweeting from a single location using `--lat` and `--long`, add a `--bbox` option to tweet from random coordinates form inside that (swlat, swlon, nelat, nelon) bounding box.

e.g. kaasunestejousitus "hydropneumatic suspension" in Puumala, Finland https://twitter.com/kaikkisanat/status/746632997760282624
