### PR TITLE
Drop unsupported 2.6 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ matrix:
     - python: 3.6
     - python: 3.5
     - python: 3.4
-    - python: 3.3
     - python: 2.7
-    - python: 2.6
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ matrix:
     - python: pypy3
     - python: 3.7
       dist: xenial
-      sudo: true
     - python: 3.6
     - python: 3.5
     - python: 3.4

--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@ Everyword Bot
 
 This is a small Python script that implements an [`@everyword`](http://twitter.com/everyword)-like Twitter bot. Here's what you'll need to run it:
 
-* Python 2.6+
+* Python 2.7+, 3.4+
 * [Tweepy](http://www.tweepy.org/)
 * a plain text file, with each of your desired tweets on one line
 


### PR DESCRIPTION
## Reasons for dropping old ones

* https://en.wikipedia.org/wiki/CPython#Version_history

### 2.6

* https://snarky.ca/stop-using-python-2-6/
* http://www.curiousefficiency.org/posts/2015/04/stop-supporting-python26.html
* http://www.python3statement.org
* Current pip 9 deprecates Python 2.6 support, pip 10 won't support it (https://github.com/pypa/pip/issues/3955)
* Not much PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796

### 3.3

* pip 10 will deprecate Python 3.3 support, pip 11 won't support it (https://github.com/pypa/pip/issues/3796)
* Very little PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796
