### PR TITLE
Add --dry-run option

### DIFF
--- a/everywordbot.py
+++ b/everywordbot.py
@@ -8,7 +8,8 @@ class EverywordBot(object):
                  access_token, token_secret,
                  source_file_name, index_file_name,
                  lat=None, long=None, place_id=None,
-                 prefix=None, suffix=None, bbox=None):
+                 prefix=None, suffix=None, bbox=None,
+                 dry_run=False):
         self.source_file_name = source_file_name
         self.index_file_name = index_file_name
         self.lat = lat
@@ -17,6 +18,7 @@ class EverywordBot(object):
         self.prefix = prefix
         self.suffix = suffix
         self.bbox = bbox
+        self.dry_run = dry_run
 
         auth = tweepy.OAuthHandler(consumer_key, consumer_secret)
         auth.set_access_token(access_token, token_secret)
@@ -60,10 +62,11 @@ class EverywordBot(object):
         if self.bbox:
             self.lat, self.long = self._random_point_in(self.bbox)
 
-        self.twitter.update_status(status=status_str,
-                                   lat=self.lat, long=self.long,
-                                   place_id=self.place_id)
-        self._increment_index(index)
+        if not self.dry_run:
+            self.twitter.update_status(status=status_str,
+                                       lat=self.lat, long=self.long,
+                                       place_id=self.place_id)
+            self._increment_index(index)
 
 
 def _csv_to_float_list(csv):
@@ -109,12 +112,16 @@ if __name__ == '__main__':
     parser.add_option('--suffix', dest='suffix',
                       help="string to add to the end of each post "
                            "(if you want a space, include a space)")
+    parser.add_option('-n', '--dry_run', dest='dry_run', action='store_true',
+                      help="Do everything except actually send the tweet or"
+                           "update the index file")
     (options, args) = parser.parse_args()
 
     bot = EverywordBot(options.consumer_key, options.consumer_secret,
                        options.access_token, options.token_secret,
                        options.source_file, options.index_file,
                        options.lat, options.long, options.place_id,
-                       options.prefix, options.suffix, options.bbox)
+                       options.prefix, options.suffix, options.bbox,
+                       options.dry_run)
 
     bot.post()

--- a/everywordbot.py
+++ b/everywordbot.py
@@ -62,7 +62,9 @@ class EverywordBot(object):
         if self.bbox:
             self.lat, self.long = self._random_point_in(self.bbox)
 
-        if not self.dry_run:
+        if self.dry_run:
+            print(status_str)
+        else:
             self.twitter.update_status(status=status_str,
                                        lat=self.lat, long=self.long,
                                        place_id=self.place_id)

--- a/test/test_everywordbot.py
+++ b/test/test_everywordbot.py
@@ -181,6 +181,23 @@ class TestIt(unittest.TestCase):
         self.assertEqual(float_list,
                          [59.811225, 20.623165, 70.07531, 31.569525])
 
+    def test__dry_run(self):
+        # Arrange
+        bot = EverywordBot("consumer_key", "consumer_secret",
+                           "access_token", "token_secret",
+                           "test/test_source.txt", "test/test_index.txt",
+                           dry_run=True)
+        stub = TwitterStub()
+        bot.twitter.update_status = stub.twitter_update_status
+        index_before = bot._get_current_index()
+
+        # Act
+        bot.post()
+
+        # Assert
+        index_after = bot._get_current_index()
+        self.assertEqual(index_before, index_after)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I'm moving [`@kaikkisanat`](https://twitter.com/kaikkisanat) to another server, this is to help check I've got everything set up right (files in the right place, dependencies in place) before putting it live.

If `--dry-run` is given, it will print the output instead of tweeting or updating the index file.