### PR TITLE
Avoid re-posting the final word

### DIFF
--- a/everywordbot.py
+++ b/everywordbot.py
@@ -37,11 +37,15 @@ class EverywordBot(object):
             index_fh.close()
 
     def _get_current_line(self, index):
+        found = False
         with open(self.source_file_name) as source_fh:
             # read the desired line
             for i, status_str in enumerate(source_fh):
                 if i == index:
+                    found = True
                     break
+            if not found:
+                raise EOFError("No more words")
             return status_str.strip()
 
     def _random_point_in(self, bbox):

--- a/everywordbot.py
+++ b/everywordbot.py
@@ -115,7 +115,7 @@ if __name__ == '__main__':
                       help="string to add to the end of each post "
                            "(if you want a space, include a space)")
     parser.add_option('-n', '--dry_run', dest='dry_run', action='store_true',
-                      help="Do everything except actually send the tweet or"
+                      help="Do everything except actually send the tweet or "
                            "update the index file")
     (options, args) = parser.parse_args()
 

--- a/test/test_everywordbot.py
+++ b/test/test_everywordbot.py
@@ -52,11 +52,11 @@ class TestIt(unittest.TestCase):
                            "test/test_source.txt", "index_file")
         index = 3
 
-        # Act
-        line = bot._get_current_line(index)
+        # Act / Assert
+        with self.assertRaises(EOFError) as context:
+            bot._get_current_line(index)
 
-        # Assert
-        self.assertEqual(line, "word3")
+        self.assertIn("No more words", str(context.exception))
 
     def test__get_current_index_file_not_exist(self):
         # Arrange

--- a/test/test_everywordbot.py
+++ b/test/test_everywordbot.py
@@ -45,6 +45,19 @@ class TestIt(unittest.TestCase):
         # Assert
         self.assertEqual(line, "word2")
 
+    def test__get_current_line_no_more_words(self):
+        # Arrange
+        bot = EverywordBot("consumer_key", "consumer_secret",
+                           "access_token", "token_secret",
+                           "test/test_source.txt", "index_file")
+        index = 3
+
+        # Act
+        line = bot._get_current_line(index)
+
+        # Assert
+        self.assertEqual(line, "word3")
+
     def test__get_current_index_file_not_exist(self):
         # Arrange
         bot = EverywordBot("consumer_key", "consumer_secret",


### PR DESCRIPTION
After [kaikkisanat](https://twitter.com/kaikkisanat) finished its five-year run [yesterday](https://twitter.com/hugovk/status/1329162448725798914) it went silent, so I didn't bother turning off the cron.

But some dozen or so hours later it sent out the last word again. I deleted it, and it re-sent it on a later cron run.

I've disabled the cron, but it looks like everywordbot kept trying to post the final word (and incrementing the index past the total count), and Twitter had been rejecting it due to duplicate content, until X hours later when it let one through.

This PR raises an `EOFError` exception when there are no more words left to tweet, to make sure the last word isn't re-posted.
